### PR TITLE
Better linetrace performance

### DIFF
--- a/mirte_robot/linetrace.py
+++ b/mirte_robot/linetrace.py
@@ -26,7 +26,9 @@ def load_mirte_module(stepper, do_step):
        global do_step
        if event != 'line':
            return
-       server.send_message_to_all(str(frame.f_lineno))
+       # Only return line number to websocket when in step mode
+       if stepper.value:
+          server.send_message_to_all(str(frame.f_lineno))
        while stepper.value and not do_step.value:
           time.sleep(.01)
        do_step.value = False

--- a/mirte_robot/linetrace.py
+++ b/mirte_robot/linetrace.py
@@ -2,6 +2,7 @@
 #TODO: for debugging purposes we could *also* listen to keyboard events
 
 import sys
+import os
 import logging
 from importlib.machinery import SourceFileLoader
 import time
@@ -36,6 +37,11 @@ def load_mirte_module(stepper, do_step):
        if not filename.endswith('mirte.py'):
           return
        return trace_lines
+
+    # Send the PID to the web interface and give it some time to call strace on this process
+    # to see the output of this script
+    server.send_message_to_all("pid:" + str(os.getpid()))
+    time.sleep(0.1)
 
     sys.settrace(traceit)
     # rospy.init_node() for some reason needs to be called from __main__ when importing in the regular way.


### PR DESCRIPTION
Only send linenumbers when in debugging/step mode. And adhere to new webinterface expectations.