### PR TITLE
Adding extra check to make sure running process stops

### DIFF
--- a/mirte_robot/linetrace.py
+++ b/mirte_robot/linetrace.py
@@ -19,7 +19,9 @@ do_step = multiprocessing.Value('b', False)
 is_running = False
 
 def stop_mirte():
+     global is_running
      process.terminate()
+     is_running = False
 
 def load_mirte_module(stepper, do_step):
 
@@ -91,7 +93,6 @@ def message_received(client, server, message):
    if message == "e": #exit (stop)
       stepper.value = True
       do_step.value = False
-      is_running = False
       stop_mirte()
 
 server = WebsocketServer(host="0.0.0.0", port=8001, loglevel=logging.CRITICAL)


### PR DESCRIPTION
Every now and then we ran into the issue that the play button did not work anymore. Apparently this was due to the fact that the old process was not terminated correctly. Since the issue itself is hard to reproduce, I therefore do not know in what kind of stat this happens. I therefore implemented a version that at least gives the user a better experience (linetrace will not 'hang'). But the actual cause (not correctly terminating the previous process) is not fixed.