### PR TITLE
Fixing linetrace running issue where play did not work all the time

### DIFF
--- a/mirte_robot/linetrace.py
+++ b/mirte_robot/linetrace.py
@@ -22,9 +22,9 @@ running = multiprocessing.Value('b', False)
 # 1) the code finishes
 # 2) the user stopped the process
 # 3) the websocket connection is closed
-def stop_mirte(terminate = True):
+def stop_mirte():
      global running
-     if terminate:
+     if running.value:
         process.terminate()
      running.value = False
 
@@ -68,8 +68,8 @@ def load_mirte_module(stepper, do_step, running):
 
     # Sending the linetrace 0 to the client
     server.send_message_to_all("0")
-
-    stop_mirte(False)
+    running.value = False
+    stop_mirte()
 
 process = multiprocessing.Process(target = load_mirte_module, args=(stepper, do_step))
 


### PR DESCRIPTION
Fixes #11 . The running variable also needed to be set to false when the program stopped executing (and therefore not calling the process.terminate()).